### PR TITLE
Fix dependency installation in weekly reminders workflow

### DIFF
--- a/.github/workflows/weekly-reminders.yml
+++ b/.github/workflows/weekly-reminders.yml
@@ -18,14 +18,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'  # Using a more stable Python version
           cache: 'pip'
           
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          # Install specific packages directly instead of using requirements.txt
-          pip install PyGithub==2.1.1 pandas==2.2.0 tabulate==0.9.0 pytz==2024.1 python-dateutil==2.8.2
+          # Install packages one by one to handle any installation issues
+          pip install PyGithub==2.1.1
+          pip install pytz==2024.1
+          pip install python-dateutil==2.8.2
+          pip install --no-deps pandas==2.2.0
+          pip install numpy  # Required for pandas
+          pip install tabulate==0.9.0
           pip freeze
 
       - name: Create Weekly Reminder


### PR DESCRIPTION
- Use Python 3.10 for better stability\n- Install dependencies one by one\n- Add numpy as explicit dependency for pandas